### PR TITLE
Fix/handle style in svelte head

### DIFF
--- a/src/extractMessages/test/data/dummy.svelte
+++ b/src/extractMessages/test/data/dummy.svelte
@@ -30,3 +30,15 @@
         <button label={__('Logout')} />
     </section>
 </div>
+
+<svelte:window on:focus={() => {}} />
+
+<svelte:head>
+    <style>
+        p {
+            color: red;
+        }
+    </style>
+</svelte:head>
+
+<svelte:body on:blur={() => {}} />


### PR DESCRIPTION
After recent [component changes](https://github.com/oat-sa/live-design-system/pull/452), the extractTranslations plugin is failing in https://github.com/oat-sa/tao-deliver-testrunner-nui-fe with the following error:

<img width="654" alt="Screenshot 2021-03-22 at 16 40 07" src="https://user-images.githubusercontent.com/43652944/112016735-46a5eb00-8b2d-11eb-93a3-509954613878.png">

It happens specifically when there is a 2nd `<style>` tag, nested inside a `<svelte:head>`, and the parser replaces the lines starting from the original `<style>` tag, down to the second `</style>` which is nested, leaving an orphaned `</svelte:head>`:

```
<style> <!-- begin ignore -->
  .foo { color: bar; }
</style>

<svelte:head>
  <style>
  </style> <!-- end ignore -->
</svelte:head>
```

Fixed by refactoring so the`<svelte:head>` block is detected for ignoring first, and then the main `<style>`.

Test with `npm run test` and `npm run extract:translationKeys` in deliver testrunner (it should finish without errors and generate a full updated messages.pot file with over 1170 lines i.e. longer than the [last one](https://github.com/oat-sa/tao-deliver-testrunner-nui-fe/blob/master/src/locale/messages.pot)).