### PR TITLE
Fix/generate POT without duplicates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5227,9 +5227,9 @@
             }
         },
         "svelte": {
-            "version": "3.23.1",
-            "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.23.1.tgz",
-            "integrity": "sha512-HTKVSDHcn4ztxRl3g425pwihePXkCvn4B2gO5Y3n3GHzHZWxYM9T+l/LHs7HjJjcI7Xl7/ujnfA3S45pz0qXIg=="
+            "version": "3.32.3",
+            "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.32.3.tgz",
+            "integrity": "sha512-5etu/wDwtewhnYO/631KKTjSmFrKohFLWNm1sWErVHXqGZ8eJLqrW0qivDSyYTcN8GbUqsR4LkIhftNFsjNehg=="
         },
         "symbol-tree": {
             "version": "3.2.4",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "scripts": {
         "extract": "node ./bin/extractTranslations.js",
         "lint": "eslint -c .eslintrc.js --ext js .",
-        "test": "jest"
+        "test": "jest",
+        "test:update": "jest -u"
     },
     "repository": {
         "type": "git",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
         "glob": "^7.1.6",
         "minimatch": "^3.0.4",
         "pofile": "^1.1.1",
-        "svelte": "^3.23.1"
+        "svelte": "3.32.3"
     },
     "devDependencies": {
         "@oat-sa/eslint-config-tao": "^0.1.0",

--- a/src/extractMessages/extractMessages.js
+++ b/src/extractMessages/extractMessages.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2020 (original work) Open Assessment Technologies SA
+ * Copyright (c) 2020-2022 (original work) Open Assessment Technologies SA
  *
  */
 

--- a/src/extractMessages/extractMessages.js
+++ b/src/extractMessages/extractMessages.js
@@ -37,7 +37,7 @@ function checkIfI18nMethodCall (node, methodName) {
  * @param {string} fileContent - source code of the file
  * @param {string} fileName - Name of the file
  * @param {string} [relativeTo] - File context will be relative to this path
- * @returns {Map<string, Object[]>}
+ * @returns {Map<Object, Object[]>}
  */
 module.exports = function extractMessages(fileContent, fileName, relativeTo) {
     const fileExt = path.extname(fileName);

--- a/src/extractMessages/extractMessages.js
+++ b/src/extractMessages/extractMessages.js
@@ -83,7 +83,8 @@ module.exports = function extractMessages(fileContent, fileName, relativeTo) {
                             line: node.loc.start.line
                         };
                         if (type === 'Literal') {
-                            const key = [...strings.keys()].find((item) => item.msgid === value) || { msgid: value };
+                            const escapedValue = value.replace(/["]/g, '\\"');
+                            const key = [...strings.keys()].find((item) => item.msgid === escapedValue) || { msgid: escapedValue };
                             strings.set(key, [...(strings.get(key) || []), context]);
                         } else {
                             /* eslint-disable no-console */

--- a/src/extractMessages/test/__snapshots__/extractMessages.spec.js.snap
+++ b/src/extractMessages/test/__snapshots__/extractMessages.spec.js.snap
@@ -44,6 +44,14 @@ Map {
       "line": 8,
     },
   ],
+  Object {
+    "msgid": "string with \\\\\\"double quotes\\\\\\" inside",
+  } => Array [
+    Object {
+      "file": "dummy.js",
+      "line": 9,
+    },
+  ],
 }
 `;
 

--- a/src/extractMessages/test/data/dummy.js
+++ b/src/extractMessages/test/data/dummy.js
@@ -6,5 +6,6 @@ export default () => {
         const string4 = __.p('Key', 'Plural key', 5);
         const string5 = __.p('Duplicate key', 'Duplicate plural key', 5);
         const string6 = __.p('Duplicate key', 'Duplicate plural key', 7);
+        const string7 = __('string with "double quotes" inside');
     };
 };

--- a/src/generatePOT/generatePOT.js
+++ b/src/generatePOT/generatePOT.js
@@ -30,13 +30,18 @@ module.exports = function generatePOT(strings) {
     const msgids = new Set(); // avoids duplicates
     const msgid_plurals = new Set();
 
-    const getPotHeader = () =>
-`msgid ""
+    const getPotHeader = () => `msgid ""
 msgstr ""
-"Content-Type: text/plain; charset=UTF-8\\n"
-"Language: en\\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\\n"
+"Project-Id-Version: \\n"
 "POT-Creation-Date: ${new Date().toISOString().slice(0,16).replace('T',' ')}\\n"
+"PO-Revision-Date: \\n"
+"Last-Translator: \\n"
+"Language-Team: \\n"
+"Language: en\\n"
+"MIME-Version: 1.0\\n"
+"Content-Type: text/plain; charset=UTF-8\\n"
+"Content-Transfer-Encoding: 8bit\\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\\n"
 "X-Generator: tao-i18n-tools\\n"
 
 `;

--- a/src/generatePOT/generatePOT.js
+++ b/src/generatePOT/generatePOT.js
@@ -30,6 +30,17 @@ module.exports = function generatePOT(strings) {
     const msgids = new Set(); // avoids duplicates
     const msgid_plurals = new Set();
 
+    const getPotHeader = () =>
+`msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\\n"
+"Language: en\\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\\n"
+"POT-Creation-Date: ${new Date().toISOString().slice(0,16).replace('T',' ')}\\n"
+"X-Generator: tao-i18n-tools\\n"
+
+`;
+
     strings.forEach((contexts, meta) => {
         const messageContext = contexts.map(context => `#: ${context.file}:${context.line}`).join('\n');
         const metaString = Object.keys(meta).reduce((accumulator, key) => {
@@ -49,5 +60,5 @@ module.exports = function generatePOT(strings) {
         }
     });
 
-    return potContent;
+    return getPotHeader() + potContent;
 };

--- a/src/generatePOT/generatePOT.js
+++ b/src/generatePOT/generatePOT.js
@@ -13,19 +13,22 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2020 (original work) Open Assessment Technologies SA
+ * Copyright (c) 2020-2022 (original work) Open Assessment Technologies SA
  *
  */
 
 /**
  * Writes the strings to POT file
  *
- * Skips the duplicate strings
+ * Removes the duplicate strings
  * @param {Map<Object, Object[]}
  * @returns {string}
  */
 module.exports = function generatePOT(strings) {
     let potContent = '';
+
+    const msgids = new Set(); // avoids duplicates
+    const msgid_plurals = new Set();
 
     strings.forEach((contexts, meta) => {
         const messageContext = contexts.map(context => `#: ${context.file}:${context.line}`).join('\n');
@@ -34,7 +37,16 @@ module.exports = function generatePOT(strings) {
             return accumulator;
         }, '');
 
-        potContent += `${messageContext}\n${metaString}msgstr${meta.msgid_plural ? '[0]' : ''} ""\n`;
+        // add entry if msgid or msgid_plural are new
+        if ((meta.msgid && !msgids.has(meta.msgid)) || (meta.msgid_plural && !msgid_plurals.has(meta.msgid_plural))) {
+            potContent += `${messageContext}\n${metaString}msgstr${meta.msgid_plural ? '[0]' : ''} ""\n`;
+            if (meta.msgid) {
+                msgids.add(meta.msgid);
+            }
+            if (meta.msgid_plural) {
+                msgid_plurals.add(meta.msgid_plural);
+            }
+        }
     });
 
     return potContent;

--- a/src/generatePOT/test/__snapshots__/generatePOT.spec.js.snap
+++ b/src/generatePOT/test/__snapshots__/generatePOT.spec.js.snap
@@ -15,5 +15,13 @@ msgstr \\"\\"
 msgid \\"Remove test\\"
 msgid_plural \\"Remove tests\\"
 msgstr[0] \\"\\"
+#: ../../src/bootstrap-duplicates.js:123
+msgid \\"Remove test\\"
+msgid_plural \\"Remove the tests\\"
+msgstr[0] \\"\\"
+#: ../../src/bootstrap-duplicates.js:1234
+msgid \\"Remove a test\\"
+msgid_plural \\"Remove tests\\"
+msgstr[0] \\"\\"
 "
 `;

--- a/src/generatePOT/test/__snapshots__/generatePOT.spec.js.snap
+++ b/src/generatePOT/test/__snapshots__/generatePOT.spec.js.snap
@@ -1,7 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`generatePOT should return right POT content 1`] = `
-"#: index.js:13
+"msgid \\"\\"
+msgstr \\"\\"
+\\"Content-Type: text/plain; charset=UTF-8\\\\n\\"
+\\"Language: en\\\\n\\"
+\\"Plural-Forms: nplurals=2; plural=(n != 1);\\\\n\\"
+\\"POT-Creation-Date: 2022-07-27 00:00\\\\n\\"
+\\"X-Generator: tao-i18n-tools\\\\n\\"
+
+#: index.js:13
 msgid \\"All work is done!\\"
 msgstr \\"\\"
 #: ../src/controller/runner.js:31

--- a/src/generatePOT/test/__snapshots__/generatePOT.spec.js.snap
+++ b/src/generatePOT/test/__snapshots__/generatePOT.spec.js.snap
@@ -3,10 +3,16 @@
 exports[`generatePOT should return right POT content 1`] = `
 "msgid \\"\\"
 msgstr \\"\\"
-\\"Content-Type: text/plain; charset=UTF-8\\\\n\\"
-\\"Language: en\\\\n\\"
-\\"Plural-Forms: nplurals=2; plural=(n != 1);\\\\n\\"
+\\"Project-Id-Version: \\\\n\\"
 \\"POT-Creation-Date: 2022-07-27 00:00\\\\n\\"
+\\"PO-Revision-Date: \\\\n\\"
+\\"Last-Translator: \\\\n\\"
+\\"Language-Team: \\\\n\\"
+\\"Language: en\\\\n\\"
+\\"MIME-Version: 1.0\\\\n\\"
+\\"Content-Type: text/plain; charset=UTF-8\\\\n\\"
+\\"Content-Transfer-Encoding: 8bit\\\\n\\"
+\\"Plural-Forms: nplurals=2; plural=(n != 1);\\\\n\\"
 \\"X-Generator: tao-i18n-tools\\\\n\\"
 
 #: index.js:13

--- a/src/generatePOT/test/generatePOT.spec.js
+++ b/src/generatePOT/test/generatePOT.spec.js
@@ -81,6 +81,14 @@ describe('API', () => {
 });
 
 describe('generatePOT', () => {
+    beforeEach(() => {
+        const start = new Date('2022-07-27');
+        jest.spyOn(global, 'Date').mockImplementation(() => start);
+    });
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
     it('should return right POT content', function() {
         const generatePotContent = generatePOT(strings);
 

--- a/src/generatePOT/test/generatePOT.spec.js
+++ b/src/generatePOT/test/generatePOT.spec.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2020 (original work) Open Assessment Technologies SA
+ * Copyright (c) 2020-2022 (original work) Open Assessment Technologies SA
  *
  */
 
@@ -46,6 +46,26 @@ beforeAll(() => {
                 msgid_plural: 'Remove tests'
             },
             [{ file: '../../src/bootstrap.js', line: 12 }]
+        ],
+        [
+            {
+                msgid: 'Remove test' // skip, as msgid duplicated
+            },
+            [{ file: '../../src/bootstrap-duplicates.js', line: 12 }]
+        ],
+        [
+            {
+                msgid: 'Remove test', // keep, as msgid duplicated but msgid_plural unique
+                msgid_plural: 'Remove the tests'
+            },
+            [{ file: '../../src/bootstrap-duplicates.js', line: 123 }]
+        ],
+        [
+            {
+                msgid: 'Remove a test', // keep, as msgid_plural duplicated but msgid unique
+                msgid_plural: 'Remove tests'
+            },
+            [{ file: '../../src/bootstrap-duplicates.js', line: 1234 }]
         ]
     ]);
 });


### PR DESCRIPTION
I found some bugs in our POT generation, this story comes in 3 parts:

## 1. Duplicate entries and POEdit

Duplicate `msgid` entries were not being deduplicated as the code claimed, due to [objects being used as Map keys here](https://github.com/oat-sa/tao-i18n-tools/blob/master/src/extractMessages/extractMessages.js#L87). Essentially, the following happens, when trying to update Map entries:
```
map.set({ msgid: 'hello' }, ['foo', 'bar']);
map.set({ msgid: 'hello' }, ['foo', 'bar', 'baz']);
map.size === 2; // true, but we wanted it to stay 1
```
At first I thought we should hash the keys ([similar topic discussed elsewhere](https://esdiscuss.org/topic/maps-with-object-keys)).
In the end I wasn't able to fix this in `extractMessages.js` without completely modifying the Map structure. So instead I added the deduplication in the simpler `generatePOT.js`. It got a bit more complex due to the singular and plural `msgid`s.

My motivation for cleaning up the many duplicates, is that [POEdit](https://poedit.net/download) throws errors when you try to update a translated PO file from a POT. Now it will perform this action without errors, which is good for translators.

💡 _Errors (or duplicates) in the POT file can be checked with the UNIX command:_ `msgfmt -v -c messages.pot`.

## 2. Escaping double quotes in strings

Very recently one of our apps added the following POT entry:
```
msgid "The value is invalid. Try "10px" or "2em" or simply "2"."
```
Since the inner double quotes are not escaped, it goes against the POT syntax, and `msgfmt` complains (weirdly, POEdit handles this line normally, adding its own backslash-escaping).
So I added simple escaping of the double quote char, and it will appear in the POT now as:
```
msgid "The value is invalid. Try \"10px\" or \"2em\" or simply \"2\"."
```
and the same in JSON, with escaped quotes.

## 3. Bonus: POT header

Since we send these POTs out, we might as well have an official file header according to the format ([see it here](https://www.gnu.org/software/trans-coord/manual/gnun/html_node/PO-Header.html)). I've added it (can't configure the project name though, unless I expose an export to the apps who use this).

---

## Test this

If you use `tao-deliver-fe`'s `develop` branch, the current POT has 4135 lines, and around 63 duplicate strings (e.g. `"Overview"`).
Link this new tool branch, and run:
```
npx lerna exec --scope @oat-sa-private/tao-deliver-app -- npm run extract:translationKeys
msgfmt -v -c packages/deliver-app/locale/messages.pot
```
The POT file now has 3953 lines, and no duplicates. The `msgfmt` command returns without errors. Unescaped double quotes appear only at the start and end of lines.
