### PR TITLE
Fix/TR-6061/proper ordering of POT file entries by first context string

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -32,7 +32,7 @@ jobs:
               run: npm run test:cov:ci
             - name: Report coverage
               if: always()
-              uses: slavcodev/coverage-monitor-action@1.1.0
+              uses: slavcodev/coverage-monitor-action@1.1.2
               with:
                   github_token: ${{ secrets.GITHUB_TOKEN }}
                   clover_file: coverage/clover.xml

--- a/src/rollup/i18n.js
+++ b/src/rollup/i18n.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2020 (original work) Open Assessment Technologies SA ;
+ * Copyright (c) 2020-2024 (original work) Open Assessment Technologies SA ;
  */
 
 const path = require('path');
@@ -22,6 +22,31 @@ const { minimatch } = require('minimatch');
 const extractMessages = require('../extractMessages/extractMessages');
 const generatePOT = require('../generatePOT/generatePOT');
 
+/**
+ * Comparison function for sorting i18n message contexts
+ * @param {Object} ctx1
+ * @param {String} ctx1.file
+ * @param {Number} ctx1.line
+ * @param {Object} ctx2
+ * @param {String} ctx2.file
+ * @param {Number} ctx2.line
+ * @returns {Number}
+ */
+function compareContexts(ctx1, ctx2) {
+    if (ctx1.file > ctx2.file) {
+        return 1;
+    }
+    if (ctx1.file < ctx2.file) {
+        return -1;
+    }
+    return ctx1.line > ctx2.line ? 1 : 0;
+}
+
+/**
+ * Rollup plugin - extracts i18n messages from a source codebase, and writes POT file as output
+ * @param {Object} options
+ * @returns {Object} Rollup plugin API
+ */
 module.exports = (options = {}) => {
     if (typeof options.output !== 'string') {
         throw new Error('"output" has to be defined');
@@ -38,28 +63,20 @@ module.exports = (options = {}) => {
             ) {
                 extractMessages(source, id, path.dirname(options.output)).forEach((context, message) => {
                     const contexts = [...(messages.get(message) || []), ...context];
-                    // sort the context to have the same order everytime
+                    // sort by context file:line to have the same order everytime
                     messages.set(
                         message,
-                        contexts.sort((a, b) => {
-                            if (a.file > b.file) {
-                                return 1;
-                            }
-
-                            if (a.file < b.file) {
-                                return -1;
-                            }
-
-                            return a.line > b.line ? 1 : 0;
-                        })
+                        contexts.sort(compareContexts)
                     );
                 });
             }
             return null;
         },
         buildEnd() {
-            // sort the messages to have the same order everytime
-            const sortedMessages = new Map([...messages].sort());
+            // sort the messages by first context's file:line to have the same order everytime
+            const sortedMessages = new Map([...messages].sort((a, b) => {
+                return compareContexts(a[1][0], b[1][0]);
+            }));
             return fs.promises.writeFile(options.output, generatePOT(sortedMessages));
         }
     };


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/TR-6061

We've had issues forever with the order of entries in [deliver-app/locale/messages.POT](https://github.com/oat-sa/tao-deliver-fe/blob/main/packages/deliver-app/locale/messages.pot) randomly changing and causing merge conflicts.

This PR should fix the sorting and make POT files more stable.

**To test:**
- in `tao-deliver-fe`, replace the file contents at `node_modules/@oat-sa/tao-i18n-tools/src/rollup/i18n.js`
- run `npx lerna exec --scope @oat-sa-private/tao-deliver-app npm run extract:translationKeys`
- messages.POT will be regenerated with numerous changes
- check that the order of its entries is following the lexicographic order of the first contexts (file paths)
- rename that file to `messages2.POT`
- run the extraction command again
- `diff messages.POT messages2.POT` - only the time should have changed

**Impact**
This `i18n` plugin is used today in [tao-deliver-fe](https://github.com/oat-sa/tao-deliver-fe), [pisa-deliver-fe](https://github.com/oat-sa/pisa-deliver-fe), [proctoring/frontend](https://github.com/oat-sa/proctoring) and [tao-manual-scoring](https://github.com/oat-sa/tao-manual-scoring-fe). Only the first 2 of those also have a CI translations workflow running the command. We can upgrade them according to any schedule.