### PR TITLE
Feat: FUN-2094 support Svelte 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,42 +2,60 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.0.0] - 05-03-2025
+
+### Changed
+
+-   Updated Svelte to v5
+
+## [0.6.0] - 06-03-2024
+
+### Changed
+
+-   Updated Svelte to v3.59.2
+
+## [0.5.0] - 26-04-2023
+
+### Changed
+
+-   Upgraded to Node 18
+
 ## [0.4.0] - 21-08-2022
 
 ### Fixed
 
-- Generate POT without duplicates
+-   Generate POT without duplicates
 
 ### Added
 
-- Add POT header
+-   Add POT header
 
 ## [0.3.0] - 12-08-2021
 
 ### Added
 
-- Pluralization
+-   Pluralization
 
 ## [0.2.1] - 23-03-2021
 
 ### Changed
 
-- Handle style in Svelte `<head>`
+-   Handle style in Svelte `<head>`
 
 ## [0.2.0] - 15-06-2020
 
 ### Added
 
-- Create Rollup plugin
+-   Create Rollup plugin
 
 ## [0.1.1] - 23-03-2020
 
 ### Changed
 
-- Fixed package name in readme and added warning
+-   Fixed package name in readme and added warning
 
 ## [0.1.0] - 19-03-2020
 
 ### Added
 
-- Extract translations script (Svelte and JS)
+-   Extract translations script (Svelte and JS)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
--   Updated Svelte to v5
+-   Updated Svelte to v5.20.4
 
 ## [0.6.0] - 06-03-2024
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,21 @@
 {
     "name": "@oat-sa/tao-i18n-tools",
-    "version": "0.6.0",
+    "version": "1.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@oat-sa/tao-i18n-tools",
-            "version": "0.6.0",
+            "version": "1.0.0",
             "license": "GPL-2.0",
             "dependencies": {
                 "@rollup/pluginutils": "^4.1.0",
                 "commander": "^4.1.1",
+                "estree-walker": "^2.0.2",
                 "glob": "^7.2.3",
                 "minimatch": "^9.0.0",
                 "pofile": "^1.1.4",
-                "svelte": "^3.59.2"
+                "svelte": "^5.20.4"
             },
             "bin": {
                 "extract": "bin/extractTranslations.js"
@@ -31,13 +32,13 @@
             }
         },
         "node_modules/@ampproject/remapping": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz",
-            "integrity": "sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==",
-            "dev": true,
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+            "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+            "license": "Apache-2.0",
             "dependencies": {
-                "@jridgewell/gen-mapping": "^0.3.0",
-                "@jridgewell/trace-mapping": "^0.3.9"
+                "@jridgewell/gen-mapping": "^0.3.5",
+                "@jridgewell/trace-mapping": "^0.3.24"
             },
             "engines": {
                 "node": ">=6.0.0"
@@ -1177,14 +1178,14 @@
             }
         },
         "node_modules/@jridgewell/gen-mapping": {
-            "version": "0.3.3",
-            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
-            "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
-            "dev": true,
+            "version": "0.3.8",
+            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
+            "integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
+            "license": "MIT",
             "dependencies": {
-                "@jridgewell/set-array": "^1.0.1",
+                "@jridgewell/set-array": "^1.2.1",
                 "@jridgewell/sourcemap-codec": "^1.4.10",
-                "@jridgewell/trace-mapping": "^0.3.9"
+                "@jridgewell/trace-mapping": "^0.3.24"
             },
             "engines": {
                 "node": ">=6.0.0"
@@ -1194,41 +1195,34 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
             "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
-            "dev": true,
             "engines": {
                 "node": ">=6.0.0"
             }
         },
         "node_modules/@jridgewell/set-array": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-            "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
-            "dev": true,
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+            "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
+            "license": "MIT",
             "engines": {
                 "node": ">=6.0.0"
             }
         },
         "node_modules/@jridgewell/sourcemap-codec": {
-            "version": "1.4.15",
-            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-            "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
-            "dev": true
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+            "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+            "license": "MIT"
         },
         "node_modules/@jridgewell/trace-mapping": {
-            "version": "0.3.18",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.18.tgz",
-            "integrity": "sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==",
-            "dev": true,
+            "version": "0.3.25",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+            "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+            "license": "MIT",
             "dependencies": {
-                "@jridgewell/resolve-uri": "3.1.0",
-                "@jridgewell/sourcemap-codec": "1.4.14"
+                "@jridgewell/resolve-uri": "^3.1.0",
+                "@jridgewell/sourcemap-codec": "^1.4.14"
             }
-        },
-        "node_modules/@jridgewell/trace-mapping/node_modules/@jridgewell/sourcemap-codec": {
-            "version": "1.4.14",
-            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-            "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
-            "dev": true
         },
         "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
             "version": "5.1.1-v1",
@@ -1291,11 +1285,37 @@
                 "eslint": "^8.0.0"
             }
         },
+        "node_modules/@oat-sa/eslint-config-tao/node_modules/eslint-plugin-svelte3": {
+            "version": "3.4.1",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-svelte3/-/eslint-plugin-svelte3-3.4.1.tgz",
+            "integrity": "sha512-7p59WG8qV8L6wLdl4d/c3mdjkgVglQCdv5XOTk/iNPBKXuuV+Q0eFP5Wa6iJd/G2M1qR3BkLPEzaANOqKAZczw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "peerDependencies": {
+                "eslint": ">=6.0.0",
+                "svelte": "^3.2.0"
+            }
+        },
+        "node_modules/@oat-sa/eslint-config-tao/node_modules/svelte": {
+            "version": "3.59.2",
+            "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.59.2.tgz",
+            "integrity": "sha512-vzSyuGr3eEoAtT/A6bmajosJZIUWySzY2CzB3w2pgPvnkUjGqlDnsNnA0PMO+mMAhuyMul6C2uuZzY6ELSkzyA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">= 8"
+            }
+        },
         "node_modules/@oat-sa/prettier-config": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/@oat-sa/prettier-config/-/prettier-config-0.1.1.tgz",
             "integrity": "sha512-igtRpb6eaRtkomSjONelI/tXjSfk3yUHcm67jlzGsdVAX9M5S4RUJTiGIoBSDSSnfHu530rEdmM8FNvJG//rbQ==",
-            "dev": true
+            "dev": true,
+            "license": "GPL-2.0"
         },
         "node_modules/@rollup/pluginutils": {
             "version": "4.1.0",
@@ -1382,6 +1402,12 @@
             "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
             "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
             "dev": true
+        },
+        "node_modules/@types/estree": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+            "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+            "license": "MIT"
         },
         "node_modules/@types/graceful-fs": {
             "version": "4.1.6",
@@ -1616,10 +1642,10 @@
             }
         },
         "node_modules/acorn": {
-            "version": "8.11.3",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
-            "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
-            "dev": true,
+            "version": "8.14.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+            "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+            "license": "MIT",
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -1634,6 +1660,15 @@
             "dev": true,
             "peerDependencies": {
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            }
+        },
+        "node_modules/acorn-typescript": {
+            "version": "1.4.13",
+            "resolved": "https://registry.npmjs.org/acorn-typescript/-/acorn-typescript-1.4.13.tgz",
+            "integrity": "sha512-xsc9Xv0xlVfwp2o7sQ+GCQ1PgbkdcpWdTzrwXxO3xDMTAywVS3oXVOcOHuRjAPkS4P9b+yc/qNF15460v+jp4Q==",
+            "license": "MIT",
+            "peerDependencies": {
+                "acorn": ">=8.9.0"
             }
         },
         "node_modules/ajv": {
@@ -1714,6 +1749,15 @@
                 "sprintf-js": "~1.0.2"
             }
         },
+        "node_modules/aria-query": {
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+            "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/array-union": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
@@ -1721,6 +1765,15 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/axobject-query": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+            "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/babel-jest": {
@@ -1979,6 +2032,15 @@
             },
             "engines": {
                 "node": ">=12"
+            }
+        },
+        "node_modules/clsx": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+            "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/co": {
@@ -2346,19 +2408,6 @@
             },
             "engines": {
                 "node": ">=10"
-            }
-        },
-        "node_modules/eslint-plugin-svelte3": {
-            "version": "3.4.1",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-svelte3/-/eslint-plugin-svelte3-3.4.1.tgz",
-            "integrity": "sha512-7p59WG8qV8L6wLdl4d/c3mdjkgVglQCdv5XOTk/iNPBKXuuV+Q0eFP5Wa6iJd/G2M1qR3BkLPEzaANOqKAZczw==",
-            "dev": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "peerDependencies": {
-                "eslint": ">=6.0.0",
-                "svelte": "^3.2.0"
             }
         },
         "node_modules/eslint-scope": {
@@ -2763,6 +2812,12 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/esm-env": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
+            "integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
+            "license": "MIT"
+        },
         "node_modules/espree": {
             "version": "9.5.1",
             "resolved": "https://registry.npmjs.org/espree/-/espree-9.5.1.tgz",
@@ -2826,6 +2881,15 @@
                 "node": ">=4.0"
             }
         },
+        "node_modules/esrap": {
+            "version": "1.4.5",
+            "resolved": "https://registry.npmjs.org/esrap/-/esrap-1.4.5.tgz",
+            "integrity": "sha512-CjNMjkBWWZeHn+VX+gS8YvFwJ5+NDhg8aWZBSFJPR8qQduDNjbJodA2WcwCm7uQa5Rjqj+nZvVmceg1RbHFB9g==",
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.4.15"
+            }
+        },
         "node_modules/esrecurse": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
@@ -2859,7 +2923,8 @@
         "node_modules/estree-walker": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
+            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+            "license": "MIT"
         },
         "node_modules/esutils": {
             "version": "2.0.3",
@@ -3357,6 +3422,15 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/is-reference": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
+            "integrity": "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "^1.0.6"
             }
         },
         "node_modules/is-stream": {
@@ -4165,6 +4239,12 @@
             "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
             "dev": true
         },
+        "node_modules/locate-character": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
+            "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
+            "license": "MIT"
+        },
         "node_modules/locate-path": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -4193,6 +4273,15 @@
             },
             "engines": {
                 "node": ">=10"
+            }
+        },
+        "node_modules/magic-string": {
+            "version": "0.30.17",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
+            "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.5.0"
             }
         },
         "node_modules/make-dir": {
@@ -4945,11 +5034,28 @@
             }
         },
         "node_modules/svelte": {
-            "version": "3.59.2",
-            "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.59.2.tgz",
-            "integrity": "sha512-vzSyuGr3eEoAtT/A6bmajosJZIUWySzY2CzB3w2pgPvnkUjGqlDnsNnA0PMO+mMAhuyMul6C2uuZzY6ELSkzyA==",
+            "version": "5.20.4",
+            "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.20.4.tgz",
+            "integrity": "sha512-2Mo/AfObaw9zuD0u1JJ7sOVzRCGcpETEyDkLbtkcctWpCMCIyT0iz83xD8JT29SR7O4SgswuPRIDYReYF/607A==",
+            "license": "MIT",
+            "dependencies": {
+                "@ampproject/remapping": "^2.3.0",
+                "@jridgewell/sourcemap-codec": "^1.5.0",
+                "@types/estree": "^1.0.5",
+                "acorn": "^8.12.1",
+                "acorn-typescript": "^1.4.13",
+                "aria-query": "^5.3.1",
+                "axobject-query": "^4.1.0",
+                "clsx": "^2.1.1",
+                "esm-env": "^1.2.1",
+                "esrap": "^1.4.3",
+                "is-reference": "^3.0.3",
+                "locate-character": "^3.0.0",
+                "magic-string": "^0.30.11",
+                "zimmerframe": "^1.1.2"
+            },
             "engines": {
-                "node": ">= 8"
+                "node": ">=18"
             }
         },
         "node_modules/test-exclude": {
@@ -5247,6 +5353,12 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/zimmerframe": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.2.tgz",
+            "integrity": "sha512-rAbqEGa8ovJy4pyBxZM70hg4pE6gDgaQ0Sl9M3enG3I0d6H4XSAM3GeNGLKnsBpuijUow064sf7ww1nutC5/3w==",
+            "license": "MIT"
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-i18n-tools",
-    "version": "0.6.0",
+    "version": "1.0.0",
     "description": "Internationalisation tools for tao",
     "bin": {
         "i18n:extract": "./bin/extractTranslations.js"
@@ -36,10 +36,11 @@
     "dependencies": {
         "@rollup/pluginutils": "^4.1.0",
         "commander": "^4.1.1",
+        "estree-walker": "^2.0.2",
         "glob": "^7.2.3",
         "minimatch": "^9.0.0",
         "pofile": "^1.1.4",
-        "svelte": "^3.59.2"
+        "svelte": "^5.20.4"
     },
     "devDependencies": {
         "@oat-sa/eslint-config-tao": "^2.0.0",


### PR DESCRIPTION
Ticket https://oat-sa.atlassian.net/browse/FUN-2094

Release a major version of this package updating Svelte from v3.59.2 to v5.20.4. Svelte 5 doesn't expose an ast walter any more so I had to install the `estree-walker` dependency directly.

1. See ticket description on how to reproduce the problem.

2. To reproduce the fix: 

- Get on [this](https://github.com/oat-sa/vite-app-template/pull/27) branch (`feat/svelte5-runes`)
- Use `npm link` to use this branch (`feat/FUN-2094/support-svelte5`) of `tao-i18n-tools` with the `vite-app-template` project 
- Run `npm run build` and it should work this time

## Note: This is a BREAKING CHANGE since we're using the Svelte 5 compiler. I'm also intentionally bumping the version to 1.0.0
